### PR TITLE
Update to neow3j 3.24.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,8 @@ dependencies {
             'org.junit.jupiter:junit-jupiter:5.8.2',
             'org.hamcrest:hamcrest:2.2'
 
-    deployImplementation 'io.neow3j:compiler:3.24.1'
+    deployImplementation 'io.neow3j:compiler:3.24.1',
+            'io.neow3j:contract:3.24.1'
 }
 
 tasks.withType(Test).configureEach {

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'io.neow3j.gradle-plugin' version '3.24.0'
+    id 'io.neow3j.gradle-plugin' version '3.24.1'
     id "com.github.node-gradle.node" version "7.1.0"
 }
 
@@ -14,7 +14,8 @@ version '1.0.0'
 
 repositories {
     mavenCentral()
-    maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
+    // Uncomment the following line to use snapshot versions of neow3j
+//    maven { url "https://central.sonatype.com/repository/maven-snapshots/" }
 }
 
 sourceSets {
@@ -27,14 +28,14 @@ sourceSets {
 }
 
 dependencies {
-    implementation 'io.neow3j:devpack:3.24.0'
+    implementation 'io.neow3j:devpack:3.24.1'
 
-    testImplementation 'io.neow3j:devpack-test:3.24.0',
-            'io.neow3j:compiler:3.24.0',
+    testImplementation 'io.neow3j:devpack-test:3.24.1',
+            'io.neow3j:compiler:3.24.1',
             'org.junit.jupiter:junit-jupiter:5.8.2',
             'org.hamcrest:hamcrest:2.2'
 
-    deployImplementation 'io.neow3j:compiler:3.24.0'
+    deployImplementation 'io.neow3j:compiler:3.24.1'
 }
 
 tasks.withType(Test).configureEach {

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,9 +1,8 @@
 pluginManagement {
     repositories {
-        mavenLocal()
         gradlePluginPortal()
         // For SNAPSHOTS
-        maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
+        maven { url "https://central.sonatype.com/repository/maven-snapshots/" }
     }
     resolutionStrategy {
         eachPlugin {
@@ -13,5 +12,4 @@ pluginManagement {
         }
     }
 }
-
 rootProject.name = 'grantshares-contracts'

--- a/src/main/java/com/axlabs/neo/grantshares/GrantSharesBridgeAdapter.java
+++ b/src/main/java/com/axlabs/neo/grantshares/GrantSharesBridgeAdapter.java
@@ -4,7 +4,6 @@ import io.neow3j.devpack.ByteString;
 import io.neow3j.devpack.Hash160;
 import io.neow3j.devpack.Runtime;
 import io.neow3j.devpack.Storage;
-import io.neow3j.devpack.StorageContext;
 import io.neow3j.devpack.annotations.CallFlags;
 import io.neow3j.devpack.annotations.ContractSourceCode;
 import io.neow3j.devpack.annotations.DisplayName;
@@ -26,7 +25,6 @@ import io.neow3j.devpack.events.Event1Arg;
 import static io.neow3j.devpack.Helper.abort;
 import static io.neow3j.devpack.Runtime.getCallingScriptHash;
 import static io.neow3j.devpack.Runtime.getExecutingScriptHash;
-import static io.neow3j.devpack.Storage.getStorageContext;
 
 @Permission.Permissions({
         @Permission(contract = "*", methods = {"depositGas", "depositNative", "depositToken"}),
@@ -42,8 +40,6 @@ import static io.neow3j.devpack.Storage.getStorageContext;
 @DisplayName("GrantSharesBridgeAdapter")
 @SuppressWarnings("unchecked")
 public class GrantSharesBridgeAdapter {
-
-    private static StorageContext context = getStorageContext();
 
     private final static int VERSION_KEY = 0x00;
     private final static int OWNER_KEY = 0x01;
@@ -201,7 +197,7 @@ public class GrantSharesBridgeAdapter {
         if (funder == null || !Hash160.isValid(funder) || funder.isZero()) {
             abort("invalid funder");
         }
-        Storage.put(context, WHITELISTED_FUNDER_KEY, funder);
+        Storage.put(WHITELISTED_FUNDER_KEY, funder);
         whitelistedFunderAdded.fire(funder);
     }
 
@@ -215,7 +211,7 @@ public class GrantSharesBridgeAdapter {
         if (maxFee == null || maxFee < 0) {
             abort("invalid max fee");
         }
-        Storage.put(context, MAX_FEE_KEY, maxFee);
+        Storage.put(MAX_FEE_KEY, maxFee);
         maxFeeChanged.fire(maxFee);
     }
 
@@ -224,7 +220,7 @@ public class GrantSharesBridgeAdapter {
 
     @Safe
     public static Hash160 owner() {
-        return Storage.getHash160(context.asReadOnly(), OWNER_KEY);
+        return Storage.getHash160(OWNER_KEY);
     }
 
     /**
@@ -232,7 +228,7 @@ public class GrantSharesBridgeAdapter {
      */
     @Safe
     public static int maxFee() {
-        return Storage.getInt(context.asReadOnly(), MAX_FEE_KEY);
+        return Storage.getInt(MAX_FEE_KEY);
     }
 
     /**
@@ -240,22 +236,22 @@ public class GrantSharesBridgeAdapter {
      */
     @Safe
     public static Hash160 whitelistedFunder() {
-        return Storage.getHash160(context.asReadOnly(), WHITELISTED_FUNDER_KEY);
+        return Storage.getHash160(WHITELISTED_FUNDER_KEY);
     }
 
     @Safe
     public static Hash160 grantSharesGovContract() {
-        return Storage.getHash160(context.asReadOnly(), GRANTSHARESGOV_CONTRACT_KEY);
+        return Storage.getHash160(GRANTSHARESGOV_CONTRACT_KEY);
     }
 
     @Safe
     public static Hash160 grantSharesTrasuryContract() {
-        return Storage.getHash160(context.asReadOnly(), GRANTSHARESTREASURY_CONTRACT_KEY);
+        return Storage.getHash160(GRANTSHARESTREASURY_CONTRACT_KEY);
     }
 
     @Safe
     public static Hash160 bridgeContract() {
-        return Storage.getHash160(context.asReadOnly(), BRIDGE_CONTRACT_KEY);
+        return Storage.getHash160(BRIDGE_CONTRACT_KEY);
     }
 
     // endregion
@@ -274,13 +270,13 @@ public class GrantSharesBridgeAdapter {
     @OnDeployment
     public static void deploy(Object data, boolean update) {
         if (update) {
-            if (Storage.getInt(context.asReadOnly(), VERSION_KEY) != 1) {
+            if (Storage.getInt(VERSION_KEY) != 1) {
                 abort("invalid version");
             }
-            Storage.put(context, VERSION_KEY, 2);
-            Storage.delete(context, V1_BRIDGE_VERSION_KEY);
+            Storage.put(VERSION_KEY, 2);
+            Storage.delete(V1_BRIDGE_VERSION_KEY);
         } else {
-            Storage.put(context, VERSION_KEY, 1);
+            Storage.put(VERSION_KEY, 1);
 
             // Initialize the contract.
             DeployData deployData = (DeployData) data;
@@ -288,37 +284,37 @@ public class GrantSharesBridgeAdapter {
             if (initialOwner == null || !Hash160.isValid(initialOwner) || initialOwner.isZero()) {
                 abort("invalid initial owner");
             }
-            Storage.put(context, OWNER_KEY, initialOwner);
+            Storage.put(OWNER_KEY, initialOwner);
 
             Hash160 gsGovContract = deployData.grantSharesGovContract;
             if (gsGovContract == null || !Hash160.isValid(gsGovContract) || gsGovContract.isZero()) {
                 abort("invalid GrantSharesGov contract");
             }
-            Storage.put(context, GRANTSHARESGOV_CONTRACT_KEY, gsGovContract);
+            Storage.put(GRANTSHARESGOV_CONTRACT_KEY, gsGovContract);
 
             Hash160 gsTreasury = deployData.grantSharesTreasuryContract;
             if (gsGovContract == null || !Hash160.isValid(gsTreasury) || gsTreasury.isZero()) {
                 abort("invalid GrantSharesTreasury contract");
             }
-            Storage.put(context, GRANTSHARESTREASURY_CONTRACT_KEY, gsTreasury);
+            Storage.put(GRANTSHARESTREASURY_CONTRACT_KEY, gsTreasury);
 
             Hash160 bridgeContract = deployData.bridgeContract;
             if (bridgeContract == null || !Hash160.isValid(bridgeContract) || bridgeContract.isZero()) {
                 abort("invalid bridge contract");
             }
-            Storage.put(context, BRIDGE_CONTRACT_KEY, bridgeContract);
+            Storage.put(BRIDGE_CONTRACT_KEY, bridgeContract);
 
             Integer initialMaxFee = deployData.initialMaxFee;
             if (initialMaxFee == null || initialMaxFee < 0) {
                 abort("invalid initial max fee");
             }
-            Storage.put(context, MAX_FEE_KEY, initialMaxFee);
+            Storage.put(MAX_FEE_KEY, initialMaxFee);
 
             Hash160 whitelistedFunder = deployData.initialWhitelistedFunder;
             if (whitelistedFunder == null || !Hash160.isValid(whitelistedFunder) || whitelistedFunder.isZero()) {
                 abort("invalid whitelisted funder");
             }
-            Storage.put(context, WHITELISTED_FUNDER_KEY, whitelistedFunder);
+            Storage.put(WHITELISTED_FUNDER_KEY, whitelistedFunder);
         }
     }
 

--- a/src/main/java/com/axlabs/neo/grantshares/GrantSharesBridgeAdapter.java
+++ b/src/main/java/com/axlabs/neo/grantshares/GrantSharesBridgeAdapter.java
@@ -293,7 +293,7 @@ public class GrantSharesBridgeAdapter {
             Storage.put(GRANTSHARESGOV_CONTRACT_KEY, gsGovContract);
 
             Hash160 gsTreasury = deployData.grantSharesTreasuryContract;
-            if (gsGovContract == null || !Hash160.isValid(gsTreasury) || gsTreasury.isZero()) {
+            if (gsTreasury == null || !Hash160.isValid(gsTreasury) || gsTreasury.isZero()) {
                 abort("invalid GrantSharesTreasury contract");
             }
             Storage.put(GRANTSHARESTREASURY_CONTRACT_KEY, gsTreasury);

--- a/src/main/java/com/axlabs/neo/grantshares/GrantSharesBridgeAdapter.java
+++ b/src/main/java/com/axlabs/neo/grantshares/GrantSharesBridgeAdapter.java
@@ -168,13 +168,13 @@ public class GrantSharesBridgeAdapter {
         if (callingScriptHash.equals(new GasToken().getHash())) {
             if (from == null) { // Allow Gas minting from potentially holding Neo.
                 return;
-            } else if (from.equals(grantSharesTrasuryContract()) || from.equals(whitelistedFunder())) {
+            } else if (from.equals(grantSharesTreasuryContract()) || from.equals(whitelistedFunder())) {
                 return;
             } else {
                 abort("only treasury or whitelisted funder");
             }
         } else if (callingScriptHash.equals(new NeoToken().getHash())) {
-            if (from.equals(grantSharesTrasuryContract())) {
+            if (from.equals(grantSharesTreasuryContract())) {
                 return;
             } else {
                 abort("only treasury");
@@ -245,7 +245,7 @@ public class GrantSharesBridgeAdapter {
     }
 
     @Safe
-    public static Hash160 grantSharesTrasuryContract() {
+    public static Hash160 grantSharesTreasuryContract() {
         return Storage.getHash160(GRANTSHARESTREASURY_CONTRACT_KEY);
     }
 

--- a/src/main/java/com/axlabs/neo/grantshares/GrantSharesGov.java
+++ b/src/main/java/com/axlabs/neo/grantshares/GrantSharesGov.java
@@ -12,7 +12,6 @@ import io.neow3j.devpack.Map;
 import io.neow3j.devpack.Runtime;
 import io.neow3j.devpack.Iterator.Struct;
 import io.neow3j.devpack.Storage;
-import io.neow3j.devpack.StorageContext;
 import io.neow3j.devpack.StorageMap;
 import io.neow3j.devpack.annotations.ContractSourceCode;
 import io.neow3j.devpack.annotations.DisplayName;
@@ -28,7 +27,6 @@ import io.neow3j.devpack.events.*;
 import static io.neow3j.devpack.Account.createStandardAccount;
 import static io.neow3j.devpack.Runtime.checkWitness;
 import static io.neow3j.devpack.Runtime.getTime;
-import static io.neow3j.devpack.Storage.getReadOnlyContext;
 import static io.neow3j.devpack.constants.FindOptions.ValuesOnly;
 
 @Permission(contract = "*", methods = "*")
@@ -58,13 +56,12 @@ public class GrantSharesGov {
     static final String PAUSED_KEY = "paused"; // boolean
     static final String MEMBERS_COUNT_KEY = "#_members"; // int
 
-    static final StorageContext ctx = Storage.getStorageContext();
-    static final StorageMap proposals = new StorageMap(ctx, 1); // [int id: Proposal proposal]
-    static final StorageMap proposalData = new StorageMap(ctx, 2); // [int id: ProposalData proposalData]
-    static final StorageMap proposalVotes = new StorageMap(ctx, 3); // [int id: ProposalVotes proposalVotes]
-    static final StorageMap parameters = new StorageMap(ctx, 4); // [String param_key: int param_value ]
+    static final StorageMap proposals = new StorageMap(1); // [int id: Proposal proposal]
+    static final StorageMap proposalData = new StorageMap(2); // [int id: ProposalData proposalData]
+    static final StorageMap proposalVotes = new StorageMap(3); // [int id: ProposalVotes proposalVotes]
+    static final StorageMap parameters = new StorageMap(4); // [String param_key: int param_value ]
     static final byte MEMBERS_MAP_PREFIX = 5;
-    static final StorageMap members = new StorageMap(ctx, MEMBERS_MAP_PREFIX); // [Hash160 accHash: ECPoint publicKey]
+    static final StorageMap members = new StorageMap(MEMBERS_MAP_PREFIX); // [Hash160 accHash: ECPoint publicKey]
     //endregion CONTRACT VARIABLES
 
     //region EVENTS
@@ -135,12 +132,12 @@ public class GrantSharesGov {
                 members.put(createStandardAccount(pubKey).toByteString(), pubKey.toByteString());
             }
 
-            Storage.put(ctx, MEMBERS_COUNT_KEY, pubKeys.length);
-            Storage.put(ctx, PAUSED_KEY, 0);
-            Storage.put(ctx, PROPOSALS_COUNT_KEY, 0);
+            Storage.put(MEMBERS_COUNT_KEY, pubKeys.length);
+            Storage.put(PAUSED_KEY, 0);
+            Storage.put(PROPOSALS_COUNT_KEY, 0);
         } else {
-            int proposalsCount = Storage.getInt(getReadOnlyContext(), PROPOSALS_COUNT_KEY);
-            int memberCount = Storage.getInt(getReadOnlyContext(), MEMBERS_COUNT_KEY);
+            int proposalsCount = Storage.getInt(PROPOSALS_COUNT_KEY);
+            int memberCount = Storage.getInt(MEMBERS_COUNT_KEY);
             StdLib stdLib = new StdLib();
             for (int i = 0; i < proposalsCount; i++) {
                 ProposalData proposalData = (ProposalData) stdLib.deserialize(GrantSharesGov.proposalData.get(i));
@@ -253,7 +250,7 @@ public class GrantSharesGov {
      */
     @Safe
     public static int getMembersCount() {
-        return Storage.getInt(getReadOnlyContext(), MEMBERS_COUNT_KEY);
+        return Storage.getInt(MEMBERS_COUNT_KEY);
     }
 
     /**
@@ -263,7 +260,7 @@ public class GrantSharesGov {
      */
     @Safe
     public static int getProposalCount() {
-        return Storage.getInt(getReadOnlyContext(), PROPOSALS_COUNT_KEY);
+        return Storage.getInt(PROPOSALS_COUNT_KEY);
     }
 
     /**
@@ -278,7 +275,7 @@ public class GrantSharesGov {
     public static Paginator.Paginated getProposals(int page, int itemsPerPage) throws Exception {
         if (page < 0) throw new Exception("[GrantSharesGov.getProposals] Page number was negative");
         if (itemsPerPage <= 0) throw new Exception("[GrantSharesGov.getProposals] Page number was negative or zero");
-        int n = Storage.getInt(getReadOnlyContext(), PROPOSALS_COUNT_KEY);
+        int n = Storage.getInt(PROPOSALS_COUNT_KEY);
         int[] pagination = Paginator.calcPagination(n, page, itemsPerPage);
         List<Object> list = new List<>();
         for (int i = pagination[0]; i < pagination[1]; i++) {
@@ -295,7 +292,7 @@ public class GrantSharesGov {
      */
     @Safe
     public static boolean isPaused() {
-        return Storage.getBoolean(getReadOnlyContext(), PAUSED_KEY);
+        return Storage.getBoolean(PAUSED_KEY);
     }
 
     /**
@@ -318,7 +315,7 @@ public class GrantSharesGov {
      */
     @Safe
     public static int calcMembersMultiSigAccountThreshold() throws Exception {
-        int count = Storage.getInt(getReadOnlyContext(), MEMBERS_COUNT_KEY);
+        int count = Storage.getInt(MEMBERS_COUNT_KEY);
         int thresholdRatio = parameters.getInt(MULTI_SIG_THRESHOLD_KEY);
         int thresholdTimes100 = count * thresholdRatio;
         int threshold = thresholdTimes100 / 100;
@@ -375,7 +372,7 @@ public class GrantSharesGov {
         }
         if (!areIntentsValid(intents)) Helper.abort("createProposal" + ": " + "Invalid intents");
 
-        int id = Storage.getInt(getReadOnlyContext(), PROPOSALS_COUNT_KEY);
+        int id = Storage.getInt(PROPOSALS_COUNT_KEY);
         int expiration = parameters.getInt(EXPIRATION_LENGTH_KEY) + getTime();
         StdLib stdLib = new StdLib();
         proposals.put(id, stdLib.serialize(new ProposalV2(id, expiration)));
@@ -383,7 +380,7 @@ public class GrantSharesGov {
                 new ProposalData(proposer, linkedProposal, acceptanceRate, quorum, intents, offchainUri))
         );
         proposalVotes.put(id, stdLib.serialize(new ProposalVotes()));
-        Storage.put(ctx, PROPOSALS_COUNT_KEY, id + 1);
+        Storage.put(PROPOSALS_COUNT_KEY, id + 1);
 
         // An event can take max 1024 bytes data. Thus, we're not passing the offchainUri since it could be longer.
         created.fire(id, proposer, acceptanceRate, quorum);
@@ -568,7 +565,7 @@ public class GrantSharesGov {
         Hash160 memberHash = createStandardAccount(memberPubKey);
         if (members.get(memberHash.toByteString()) != null) Helper.abort("addMember" + ": " + "Already a member");
         members.put(memberHash.toByteString(), memberPubKey.toByteString());
-        Storage.put(ctx, MEMBERS_COUNT_KEY, Storage.getInt(getReadOnlyContext(), MEMBERS_COUNT_KEY) + 1);
+        Storage.put(MEMBERS_COUNT_KEY, Storage.getInt(MEMBERS_COUNT_KEY) + 1);
         memberAdded.fire(memberHash);
     }
 
@@ -585,7 +582,7 @@ public class GrantSharesGov {
         Hash160 memberHash = createStandardAccount(memberPubKey);
         if (members.get(memberHash.toByteString()) == null) Helper.abort("removeMember" + ": " + "Not a member");
         members.delete(memberHash.toByteString());
-        Storage.put(ctx, MEMBERS_COUNT_KEY, Storage.getInt(getReadOnlyContext(), MEMBERS_COUNT_KEY) - 1);
+        Storage.put(MEMBERS_COUNT_KEY, Storage.getInt(MEMBERS_COUNT_KEY) - 1);
         memberRemoved.fire(memberHash);
     }
 
@@ -615,7 +612,7 @@ public class GrantSharesGov {
             Helper.abort("pause" + ": " + e.getMessage());
         }
         if (!checkWitness(membersMultiSigHash)) Helper.abort("pause" + ": " + "Not authorized");
-        Storage.put(ctx, PAUSED_KEY, 1);
+        Storage.put(PAUSED_KEY, 1);
         paused.fire();
     }
 
@@ -627,7 +624,7 @@ public class GrantSharesGov {
             Helper.abort("pause" + ": " + e.getMessage());
         }
         if (!checkWitness(membersMultiSigHash)) Helper.abort("unpause" + ": " + "Not authorized");
-        Storage.put(ctx, PAUSED_KEY, 0);
+        Storage.put(PAUSED_KEY, 0);
         unpaused.fire();
     }
 
@@ -638,7 +635,7 @@ public class GrantSharesGov {
     }
 
     public static void abortIfPaused() {
-        if (Storage.getBoolean(getReadOnlyContext(), PAUSED_KEY)) {
+        if (Storage.getBoolean(PAUSED_KEY)) {
             Helper.abort("abortIfPaused" + ": " + "Contract is paused");
         }
     }

--- a/src/main/java/com/axlabs/neo/grantshares/GrantSharesTreasury.java
+++ b/src/main/java/com/axlabs/neo/grantshares/GrantSharesTreasury.java
@@ -12,7 +12,6 @@ import io.neow3j.devpack.List;
 import io.neow3j.devpack.Map;
 import io.neow3j.devpack.Runtime;
 import io.neow3j.devpack.Storage;
-import io.neow3j.devpack.StorageContext;
 import io.neow3j.devpack.StorageMap;
 import io.neow3j.devpack.annotations.ContractSourceCode;
 import io.neow3j.devpack.annotations.DisplayName;
@@ -35,7 +34,6 @@ import static io.neow3j.devpack.Hash160.isValid;
 import static io.neow3j.devpack.Hash160.zero;
 import static io.neow3j.devpack.Runtime.checkWitness;
 import static io.neow3j.devpack.Runtime.getCallingScriptHash;
-import static io.neow3j.devpack.Storage.getReadOnlyContext;
 import static io.neow3j.devpack.constants.FindOptions.KeysOnly;
 import static io.neow3j.devpack.constants.FindOptions.RemovePrefix;
 import static io.neow3j.devpack.constants.FindOptions.ValuesOnly;
@@ -59,9 +57,8 @@ public class GrantSharesTreasury {
     static final String WHITELISTED_TOKENS_PREFIX = "whitelistedTokens";
     static final String MULTI_SIG_THRESHOLD_KEY = "threshold";
 
-    static final StorageContext ctx = Storage.getStorageContext();
-    static final StorageMap funders = new StorageMap(ctx, FUNDERS_PREFIX); // [hash, List<ECPoint>]
-    static final StorageMap whitelistedTokens = new StorageMap(ctx, WHITELISTED_TOKENS_PREFIX); // [hash, max_amount]
+    static final StorageMap funders = new StorageMap(FUNDERS_PREFIX); // [hash, List<ECPoint>]
+    static final StorageMap whitelistedTokens = new StorageMap(WHITELISTED_TOKENS_PREFIX); // [hash, max_amount]
 
     //region EVENTS
     @DisplayName("FunderAdded")
@@ -123,7 +120,7 @@ public class GrantSharesTreasury {
             // Set owner
             Hash160 ownerHash = (Hash160) config[0];
             assert isValid(ownerHash) && ownerHash != Hash160.zero();
-            Storage.put(ctx, OWNER_KEY, ownerHash);
+            Storage.put(OWNER_KEY, ownerHash);
 
             // Set initial funders.
             Object[][] accounts = (Object[][]) config[1]; // [  [hash, [keys...]],  [hash, [keys...]]  ]
@@ -149,7 +146,7 @@ public class GrantSharesTreasury {
             // set parameter
             int thresholdRatio = (int) config[3];
             assert thresholdRatio > 0 && thresholdRatio <= 100;
-            Storage.put(ctx, MULTI_SIG_THRESHOLD_KEY, thresholdRatio);
+            Storage.put(MULTI_SIG_THRESHOLD_KEY, thresholdRatio);
         }
     }
 
@@ -243,7 +240,7 @@ public class GrantSharesTreasury {
      * @return The multi-sig account signing threshold.
      */
     private static int calcFundersMultiSigAddressThreshold(int count) throws Exception {
-        int thresholdRatio = Storage.getInt(getReadOnlyContext(), MULTI_SIG_THRESHOLD_KEY);
+        int thresholdRatio = Storage.getInt(MULTI_SIG_THRESHOLD_KEY);
         int thresholdTimes100 = count * thresholdRatio;
         int threshold = thresholdTimes100 / 100;
         if (thresholdTimes100 % 100 != 0) {
@@ -278,8 +275,8 @@ public class GrantSharesTreasury {
      */
     @Safe
     public static boolean isPaused() {
-        return (boolean) Contract.call(new Hash160(Storage.get(getReadOnlyContext(), OWNER_KEY)),
-                "isPaused", CallFlags.ReadOnly, new Object[]{}
+        return (boolean) Contract.call(new Hash160(Storage.get(OWNER_KEY)), "isPaused", CallFlags.ReadOnly,
+                new Object[]{}
         );
     }
 
@@ -290,7 +287,7 @@ public class GrantSharesTreasury {
      */
     @Safe
     public static int getFundersMultiSigThresholdRatio() {
-        return Storage.getInt(getReadOnlyContext(), MULTI_SIG_THRESHOLD_KEY);
+        return Storage.getInt(MULTI_SIG_THRESHOLD_KEY);
     }
 
     /**
@@ -307,7 +304,7 @@ public class GrantSharesTreasury {
         if (value <= 0 || value > 100) {
             Helper.abort("setFundersMultiSigThresholdRatio" + ": " + "Invalid threshold ratio");
         }
-        Storage.put(ctx, MULTI_SIG_THRESHOLD_KEY, value);
+        Storage.put(MULTI_SIG_THRESHOLD_KEY, value);
         thresholdChanged.fire(value);
     }
 
@@ -488,7 +485,7 @@ public class GrantSharesTreasury {
     }
 
     private static void abortIfCallerIsNotOwner() {
-        if (Runtime.getCallingScriptHash().toByteString() != Storage.get(getReadOnlyContext(), OWNER_KEY)) {
+        if (Runtime.getCallingScriptHash().toByteString() != Storage.get(OWNER_KEY)) {
             Helper.abort("abortIfCallerIsNotOwner" + ": " + "Not authorised");
         }
     }

--- a/src/test/java/com/axlabs/neo/grantshares/GovernanceMembersTest.java
+++ b/src/test/java/com/axlabs/neo/grantshares/GovernanceMembersTest.java
@@ -139,11 +139,12 @@ public class GovernanceMembersTest {
         List<ECKeyPair.ECPublicKey> newMembers = gov.getMembers();
         assertThat(newMembers.size(), is(initMembers.size() + 1));
         assertThat(newMembers, containsInAnyOrder(
-                bob.getECKeyPair().getPublicKey(),
-                charlie.getECKeyPair().getPublicKey(),
-                alice.getECKeyPair().getPublicKey(),
-                denise.getECKeyPair().getPublicKey()
-        ));
+                        bob.getECKeyPair().getPublicKey(),
+                        charlie.getECKeyPair().getPublicKey(),
+                        alice.getECKeyPair().getPublicKey(),
+                        denise.getECKeyPair().getPublicKey()
+                )
+        );
 
         assertThat(gov.getMembersCount(), is(4));
     }
@@ -194,7 +195,9 @@ public class GovernanceMembersTest {
         ext.fastForwardOneBlock(PHASE_LENGTH + PHASE_LENGTH);
         String exception = gov.execute(id).signers(AccountSigner.calledByEntry(charlie)).callInvokeScript()
                 .getInvocationResult().getException();
-        assertThat(exception, containsString("Incorrect length"));
+        assertThat(exception,
+                containsString("Invalid uncompressed ECPoint encoding length: expected 65 bytes, but got 33 bytes.")
+        );
     }
     //endregion ADD MEMBER
 
@@ -249,10 +252,11 @@ public class GovernanceMembersTest {
         List<ECKeyPair.ECPublicKey> newMembers = gov.getMembers();
         assertThat(newMembers.size(), is(initMembers.size() - 1));
         assertThat(newMembers, containsInAnyOrder(
-                charlie.getECKeyPair().getPublicKey(),
-                alice.getECKeyPair().getPublicKey(),
-                denise.getECKeyPair().getPublicKey()
-        ));
+                        charlie.getECKeyPair().getPublicKey(),
+                        alice.getECKeyPair().getPublicKey(),
+                        denise.getECKeyPair().getPublicKey()
+                )
+        );
     }
 
     @Test
@@ -288,17 +292,19 @@ public class GovernanceMembersTest {
                 .getStack().get(0).getList().stream()
                 .map(StackItem::getByteArray).collect(Collectors.toList());
         assertThat(members, contains(
-                alice.getECKeyPair().getPublicKey().getEncoded(true),
-                charlie.getECKeyPair().getPublicKey().getEncoded(true),
-                denise.getECKeyPair().getPublicKey().getEncoded(true)
-        ));
+                        alice.getECKeyPair().getPublicKey().getEncoded(true),
+                        charlie.getECKeyPair().getPublicKey().getEncoded(true),
+                        denise.getECKeyPair().getPublicKey().getEncoded(true)
+                )
+        );
     }
 
     @Test
     public void calc_members_multisig_account() throws IOException {
         Account membersAccount = createMultiSigAccount(2, alice, charlie, denise);
         assertThat(gov.callInvokeFunction(CALC_MEMBER_MULTI_SIG_ACC).getInvocationResult()
-                .getStack().get(0).getAddress(), is(membersAccount.getAddress()));
+                .getStack().get(0).getAddress(), is(membersAccount.getAddress())
+        );
     }
 
 }

--- a/src/test/java/com/axlabs/neo/grantshares/bridgeadapter/BridgeAdapterTest.java
+++ b/src/test/java/com/axlabs/neo/grantshares/bridgeadapter/BridgeAdapterTest.java
@@ -303,7 +303,7 @@ public class BridgeAdapterTest {
     public void testUpdate() throws Throwable {
         ContractState contractState = neow3j.getContractState(bridgeAdapter.getScriptHash()).send().getContractState();
         assertThat(contractState.getUpdateCounter(), is(0));
-        assertThat(contractState.getNef().getChecksum(), is(834927614L));
+        assertThat(contractState.getNef().getChecksum(), is(351781674L));
 
         NeoSendRawTransaction response = updateTxBuilder().signers(calledByEntry(alice)).sign().send();
         assertFalse(response.hasError());

--- a/src/test/java/com/axlabs/neo/grantshares/bridgeadapter/BridgeAdapterTest.java
+++ b/src/test/java/com/axlabs/neo/grantshares/bridgeadapter/BridgeAdapterTest.java
@@ -303,7 +303,7 @@ public class BridgeAdapterTest {
     public void testUpdate() throws Throwable {
         ContractState contractState = neow3j.getContractState(bridgeAdapter.getScriptHash()).send().getContractState();
         assertThat(contractState.getUpdateCounter(), is(0));
-        assertThat(contractState.getNef().getChecksum(), is(351781674L));
+        assertThat(contractState.getNef().getChecksum(), is(105216769L));
 
         NeoSendRawTransaction response = updateTxBuilder().signers(calledByEntry(alice)).sign().send();
         assertFalse(response.hasError());

--- a/src/test/java/com/axlabs/neo/grantshares/util/contracts/TestBridgeV2.java
+++ b/src/test/java/com/axlabs/neo/grantshares/util/contracts/TestBridgeV2.java
@@ -19,8 +19,6 @@ import io.neow3j.devpack.events.Event4Args;
 import static io.neow3j.devpack.Helper.abort;
 import static io.neow3j.devpack.Runtime.getCallingScriptHash;
 import static io.neow3j.devpack.Runtime.getExecutingScriptHash;
-import static io.neow3j.devpack.Storage.getReadOnlyContext;
-import static io.neow3j.devpack.Storage.getStorageContext;
 
 /**
  * This is a test contract to mimic the behavior of the bridge contract.
@@ -41,7 +39,7 @@ public class TestBridgeV2 {
     @OnDeployment
     public static void deploy(Object data, boolean update) {
         if (!update) {
-            Storage.put(getStorageContext(), FEE_KEY, (int) data);
+            Storage.put(FEE_KEY, (int) data);
         }
     }
 
@@ -87,7 +85,7 @@ public class TestBridgeV2 {
 
     @Safe
     public static int gasDepositFee() {
-        return Storage.getInt(getReadOnlyContext(), FEE_KEY) * getOneWithStdLibCall();
+        return Storage.getInt(FEE_KEY) * getOneWithStdLibCall();
     }
 
     public static void depositGas(Hash160 from, Hash160 to, int amountIncludingFee, int maxFee) {
@@ -103,7 +101,7 @@ public class TestBridgeV2 {
 
     @Safe
     public static int tokenDepositFee(Hash160 token) {
-        return Storage.getInt(getReadOnlyContext(), FEE_KEY) * getOneWithStdLibCall();
+        return Storage.getInt(FEE_KEY) * getOneWithStdLibCall();
     }
 
     public static void depositToken(Hash160 token, Hash160 from, Hash160 to, int amount, int maxFee) {

--- a/src/test/java/com/axlabs/neo/grantshares/util/contracts/TestBridgeV3.java
+++ b/src/test/java/com/axlabs/neo/grantshares/util/contracts/TestBridgeV3.java
@@ -19,8 +19,6 @@ import io.neow3j.devpack.events.Event4Args;
 import static io.neow3j.devpack.Helper.abort;
 import static io.neow3j.devpack.Runtime.getCallingScriptHash;
 import static io.neow3j.devpack.Runtime.getExecutingScriptHash;
-import static io.neow3j.devpack.Storage.getReadOnlyContext;
-import static io.neow3j.devpack.Storage.getStorageContext;
 
 /**
  * This is a test contract to mimic the behavior of the bridge contract.
@@ -41,7 +39,7 @@ public class TestBridgeV3 {
     @OnDeployment
     public static void deploy(Object data, boolean update) {
         if (!update) {
-            Storage.put(getStorageContext(), FEE_KEY, (int) data);
+            Storage.put(FEE_KEY, (int) data);
         }
     }
 
@@ -87,7 +85,7 @@ public class TestBridgeV3 {
 
     @Safe
     public static int nativeDepositFee() {
-        return Storage.getInt(getReadOnlyContext(), FEE_KEY) * getOneWithStdLibCall();
+        return Storage.getInt(FEE_KEY) * getOneWithStdLibCall();
     }
 
     public static void depositNative(Hash160 from, Hash160 to, int amount, int maxFee) {
@@ -107,7 +105,7 @@ public class TestBridgeV3 {
 
     @Safe
     public static int tokenDepositFee(Hash160 token) {
-        return Storage.getInt(getReadOnlyContext(), FEE_KEY) * getOneWithStdLibCall();
+        return Storage.getInt(FEE_KEY) * getOneWithStdLibCall();
     }
 
     public static void depositToken(Hash160 token, Hash160 from, Hash160 to, int amount, int maxFee) {


### PR DESCRIPTION
This pull request updates all contracts to neow3j `3.24.1`.

It further fixes a naming mistake – renaming the read-only function `grantSharesTrasuryContract()` to `grantSharesTreasuryContract()` in the `GrantSharesBridgeAdapter` contract.